### PR TITLE
Feat/csv import/create categories by name when import contacts list

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,9 +504,9 @@ labels:
 ### 📝 **Formato CSV para Importação**
 
 ```csv
-nome,telefone,email,categoria,observacoes
-João Silva,+5511999999999,joao@email.com,Cliente VIP,Cliente preferencial
-Maria Santos,+5511888888888,maria@email.com,Prospect,Interessada em produto X
+nome,telefone,email,observacoes,categoria
+João Silva,+5511999999999,joao@email.com,Cliente preferencial,Cliente VIP
+Maria Santos,+5511888888888,maria@email.com,Interessada em produto X,Prospect
 ```
 
 ### 💬 **Integração com Chatwoot**

--- a/backend/src/controllers/csvImportController.ts
+++ b/backend/src/controllers/csvImportController.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
-import { AuthenticatedRequest } from '../middleware/auth';
 import multer from 'multer';
 import * as path from 'path';
+import { AuthenticatedRequest } from '../middleware/auth';
 import { CSVImportService } from '../services/csvImportService';
 import { ApiError } from '../types';
 
@@ -81,11 +81,11 @@ export class CSVImportController {
   static async downloadTemplate(req: AuthenticatedRequest, res: Response) {
     try {
       // CSV template com cabeçalhos em português
-      const csvTemplate = `nome,telefone,email,observacoes,categoriaId
-João Silva,+5511999999999,joao@email.com,Cliente desde 2020,550e8400-e29b-41d4-a716-446655440000
-Maria Santos,+5511888888888,maria@email.com,Fornecedor de materiais,550e8400-e29b-41d4-a716-446655440001
+      const csvTemplate = `nome,telefone,email,observacoes,categoria
+João Silva,+5511999999999,joao@email.com,Cliente desde 2020,Clientes
+Maria Santos,+5511888888888,maria@email.com,Fornecedor de materiais,Fornecedores
 Pedro Oliveira,+5511777777777,pedro@email.com,,
-Ana Costa,+5511666666666,ana@email.com,Parceiro estratégico,550e8400-e29b-41d4-a716-446655440000`;
+Ana Costa,+5511666666666,ana@email.com,Parceiro estratégico,Fornecedores`;
 
       res.setHeader('Content-Type', 'text/csv');
       res.setHeader('Content-Disposition', 'attachment; filename="template-contatos.csv"');

--- a/backend/src/services/evolutionMessageService.ts
+++ b/backend/src/services/evolutionMessageService.ts
@@ -28,7 +28,7 @@ export async function sendMessageViaEvolution(instanceName: string, phone: strin
     if (!config.host || !config.apiKey) {
       throw new Error('Configurações Evolution API não encontradas. Configure nas configurações do sistema.');
     }
-
+    console.log('sendMessageViaEvolution message', message);
     const normalizedPhone = normalizeBrazilianPhone(phone);
     let endpoint = '';
     let requestBody: any = {

--- a/backend/src/services/interactiveCampaignDispatchService.ts
+++ b/backend/src/services/interactiveCampaignDispatchService.ts
@@ -292,12 +292,13 @@ export const interactiveCampaignDispatchService = {
           // Preparar payload da mensagem
           let messagePayload: any;
 
-          if (mediaUrl) {
+          if (mediaUrl && mediaType) {
             // Mensagem com mídia
             messagePayload = {
-              media: {
+              [mediaType]: {
                 url: mediaUrl,
                 caption: personalizedMessage || undefined,
+                fileName: mediaType === 'document' ? fileName || 'document.pdf' : undefined,
               },
             };
           } else {

--- a/backend/src/services/interactiveCampaignDispatchService.ts
+++ b/backend/src/services/interactiveCampaignDispatchService.ts
@@ -297,9 +297,9 @@ export const interactiveCampaignDispatchService = {
             messagePayload = {
               [mediaType]: {
                 url: mediaUrl,
-                caption: personalizedMessage || undefined,
-                fileName: mediaType === 'document' ? fileName || 'document.pdf' : undefined,
               },
+              caption: personalizedMessage || undefined,
+              fileName: mediaType === 'document' ? fileName || 'document.pdf' : undefined,
             };
           } else {
             // Mensagem de texto

--- a/backend/src/services/interactiveCampaignFlowEngine.ts
+++ b/backend/src/services/interactiveCampaignFlowEngine.ts
@@ -202,13 +202,15 @@ export const interactiveCampaignFlowEngine = {
 
     // Procurar edge com label correspondente
     const targetEdge = edges.find((e: any) => {
-      const label = e.label?.toLowerCase();
+      //const label = e.label?.toLowerCase();
+      const label = e.sourceHandle?.toLowerCase();
       console.log('targetEdge edges', e);
-      console.log('conditionMet', conditionMet === e.sourceHandle);
-      //  return conditionMet
-      //  ? (label === 'true' || label === 'sim' || label === 'yes' || label === 'verdadeiro')
-      //  : (label === 'false' || label === 'não' || label === 'no' || label === 'falso');
-      return conditionMet === e.sourceHandle;
+      console.log('conditionMet', conditionMet);
+      console.log('label', label);
+      return conditionMet
+        ? (label === 'true' || label === 'sim' || label === 'yes' || label === 'verdadeiro')
+        : (label === 'false' || label === 'não' || label === 'no' || label === 'falso');
+      // return conditionMet === e.sourceHandle;
     });
 
     if (targetEdge) {

--- a/backend/src/services/interactiveCampaignFlowEngine.ts
+++ b/backend/src/services/interactiveCampaignFlowEngine.ts
@@ -204,9 +204,11 @@ export const interactiveCampaignFlowEngine = {
     const targetEdge = edges.find((e: any) => {
       const label = e.label?.toLowerCase();
       console.log('targetEdge edges', e);
-      return conditionMet
-        ? (label === 'true' || label === 'sim' || label === 'yes' || label === 'verdadeiro')
-        : (label === 'false' || label === 'não' || label === 'no' || label === 'falso');
+      console.log('conditionMet', conditionMet === e.sourceHandle);
+      //  return conditionMet
+      //  ? (label === 'true' || label === 'sim' || label === 'yes' || label === 'verdadeiro')
+      //  : (label === 'false' || label === 'não' || label === 'no' || label === 'falso');
+      return conditionMet === e.sourceHandle;
     });
 
     if (targetEdge) {

--- a/backend/src/services/interactiveCampaignFlowEngine.ts
+++ b/backend/src/services/interactiveCampaignFlowEngine.ts
@@ -203,7 +203,7 @@ export const interactiveCampaignFlowEngine = {
     // Procurar edge com label correspondente
     const targetEdge = edges.find((e: any) => {
       const label = e.label?.toLowerCase();
-      console.log('targetEdge label', label);
+      console.log('targetEdge edges', e);
       return conditionMet
         ? (label === 'true' || label === 'sim' || label === 'yes' || label === 'verdadeiro')
         : (label === 'false' || label === 'não' || label === 'no' || label === 'falso');

--- a/backend/src/services/interactiveCampaignFlowEngine.ts
+++ b/backend/src/services/interactiveCampaignFlowEngine.ts
@@ -4,10 +4,10 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { interactiveCampaignSessionService } from './interactiveCampaignSessionService';
-import { sendMessage } from './wahaApiService';
 import { sendMessageViaEvolution } from './evolutionMessageService';
+import { interactiveCampaignSessionService } from './interactiveCampaignSessionService';
 import { sendMessageViaQuepasa } from './quepasaMessageService';
+import { sendMessage } from './wahaApiService';
 
 const prisma = new PrismaClient();
 
@@ -135,7 +135,7 @@ export const interactiveCampaignFlowEngine = {
     }
 
     // Modo if/else tradicional
-    const { field, operator, value } = config;
+    const { field, conditionType, value } = config;
 
     // Normalizar resposta do usuário
     const normalizedResponse = userResponse.toLowerCase().trim();
@@ -144,7 +144,7 @@ export const interactiveCampaignFlowEngine = {
     let conditionMet = false;
 
     // Avaliar condição baseado no operador
-    switch (operator) {
+    switch (conditionType) {
       case 'equals':
       case '==':
         conditionMet = normalizedResponse === normalizedValue;
@@ -178,11 +178,11 @@ export const interactiveCampaignFlowEngine = {
         break;
 
       default:
-        console.warn(`⚠️ Unknown operator: ${operator}, defaulting to equals`);
-        conditionMet = normalizedResponse === normalizedValue;
+        console.warn(`⚠️ Unknown conditionType: ${conditionType}, defaulting to equals`);
+        conditionMet = normalizedResponse.includes(normalizedValue);
     }
 
-    console.log(`📊 Condition result: ${conditionMet} (response: "${normalizedResponse}" ${operator} "${normalizedValue}")`);
+    console.log(`📊 Condition result: ${conditionMet} (response: "${normalizedResponse}" ${conditionType} "${normalizedValue}")`);
 
     // Salvar resultado da condição nas variáveis da sessão
     await interactiveCampaignSessionService.updateSession(session.id, {
@@ -203,6 +203,7 @@ export const interactiveCampaignFlowEngine = {
     // Procurar edge com label correspondente
     const targetEdge = edges.find((e: any) => {
       const label = e.label?.toLowerCase();
+      console.log('targetEdge label', label);
       return conditionMet
         ? (label === 'true' || label === 'sim' || label === 'yes' || label === 'verdadeiro')
         : (label === 'false' || label === 'não' || label === 'no' || label === 'falso');

--- a/frontend/src/components/flow-nodes/NodeConfigSidebar.tsx
+++ b/frontend/src/components/flow-nodes/NodeConfigSidebar.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
-import { Node, Edge } from 'reactflow';
-import { Connection } from '../../services/interactiveCampaignApi';
 import EmojiPicker, { EmojiClickData } from 'emoji-picker-react';
+import { useEffect, useRef, useState } from 'react';
+import { Edge, Node } from 'reactflow';
+import { Connection } from '../../services/interactiveCampaignApi';
 
 interface Category {
   id: string;
@@ -678,8 +678,7 @@ export function NodeConfigSidebar({ node, nodes, edges, connections, categories 
 
                       {/* Campo de legenda para imagem e vídeo */}
                       {hasFile && ['image', 'video'].includes(config.actionType) && (
-                        <input
-                          type="text"
+                        <textarea
                           placeholder="Legenda..."
                           value={variation.caption || ''}
                           onChange={(e) => {
@@ -1156,8 +1155,7 @@ export function NodeConfigSidebar({ node, nodes, edges, connections, categories 
 
                     {/* Campo de legenda para imagem e vídeo */}
                     {hasFile && ['image', 'video'].includes(mediaType) && (
-                      <input
-                        type="text"
+                      <textarea
                         placeholder="Legenda..."
                         value={variation.caption || ''}
                         onChange={(e) => {
@@ -1255,11 +1253,10 @@ export function NodeConfigSidebar({ node, nodes, edges, connections, categories 
                   <label className="block text-sm font-medium text-gray-700 mb-2">
                     Legenda (opcional)
                   </label>
-                  <input
-                    type="text"
+                  <textarea
                     value={config.caption || ''}
                     onChange={(e) => setConfig({ ...config, caption: e.target.value })}
-                    placeholder="Digite uma legenda para a mídia..."
+                    placeholder="Digite uma legenda para a mídia... Use variáveis como {{nome}}, {{email}}, {{telefone}}, {{categoria}}, {{observacoes}}"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-primary"
                   />
                 </div>

--- a/frontend/src/pages/CampaignsPage.tsx
+++ b/frontend/src/pages/CampaignsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { Header } from '../components/Header';
 import { Portal } from '../components/Portal';
@@ -1832,9 +1832,8 @@ export function CampaignsPage() {
 
                                               {/* Campo de legenda para imagem e vídeo */}
                                               {hasFile && ['image', 'video'].includes(item.type) && (
-                                                <input
-                                                  type="text"
-                                                  placeholder="Legenda..."
+                                                <textarea
+                                                  placeholder="Legenda... Use variáveis como {{nome}}, {{email}}, {{telefone}}, {{categoria}}, {{observacoes}}"
                                                   value={variation.caption || ''}
                                                   onChange={(e) => {
                                                     const currentSequence = ('sequence' in formData.messageContent) ? formData.messageContent.sequence : [];


### PR DESCRIPTION
feat: Importação CSV com criação automática de categorias por nome ao importar lista de contatos

## Descrição

Esta PR adiciona suporte para importação/criação de categorias por nome no CSV, criando automaticamente categorias que não existem no sistema ao importa uma lista de contatos, sendo assim mais pratico do que ter com preencher o id das categorias previamente criadas.

## Mudanças

- ✅ Adiciona suporte para importação de categorias por nome no CSV
- ✅ Cria automaticamente categorias que não existem no sistema durante a importação
- ✅ Atribui cores aleatórias às novas categorias criadas
- ✅ Atualiza template CSV para usar nomes de categorias ao invés de IDs
- ✅ Adiciona método `findOrCreateCategoryByName` no `CategoryService`
- ✅ Melhora tratamento de erros na importação de categorias

## Arquivos Modificados

- `backend/src/services/categoryService.ts` - Adiciona método para buscar/criar categoria por nome
- `backend/src/services/csvImportService.ts` - Processa categorias por nome durante importação
- `backend/src/controllers/csvImportController.ts` - Atualiza template CSV
- `README.md` - Atualiza documentação do formato CSV

## Como Testar

1. Baixar o template CSV atualizado
2. Preencher a coluna `categoria` com nomes de categorias (ex: "Clientes", "Fornecedores")
3. Importar o CSV
4. Verificar que as categorias foram criadas automaticamente se não existirem
5. Verificar que os contatos foram associados às categorias corretas

## Notas

- As novas categorias criadas recebem cores aleatórias da paleta padrão
- A busca de categorias é case-insensitive
- Se houver erro ao processar uma categoria, a importação continua sem categoria para aquele contato